### PR TITLE
Only close actual modals, not other stuff on the page with is-active 

### DIFF
--- a/src/_js/modal-fx.js
+++ b/src/_js/modal-fx.js
@@ -34,7 +34,7 @@
         };
 
         var closeAll = function() {
-            var openModal = document.querySelectorAll('.' + elements.active);
+            var openModal = document.querySelectorAll('.modal.' + elements.active);
             openModal.forEach(function (modal) {
                 modal.classList.remove(elements.active);
             })


### PR DESCRIPTION
Hitting escape was removing the is-active tag from other things on my webpage.